### PR TITLE
add depends

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup(
         'ecdsa==0.11',
         'six>=1.8.0',
         'two1>=3.10.8',
+        'pycryptodome==3.4.7',
         'rlp>=0.6.0'
     ]
 )


### PR DESCRIPTION
**add pycryptodome or will get this:**

```
Traceback (most recent call last):
  File "create_btc.py", line 1, in <module>
    from pywallet import wallet
  File "/usr/lib/python3.4/site-packages/pywallet-0.0.5-py3.4.egg/pywallet/wallet.py", line 5, in <module>
    from .utils import (
  File "/usr/lib/python3.4/site-packages/pywallet-0.0.5-py3.4.egg/pywallet/utils/__init__.py", line 5, in <module>
    from .ethereum import (
  File "/usr/lib/python3.4/site-packages/pywallet-0.0.5-py3.4.egg/pywallet/utils/ethereum.py", line 30, in <module>
    from Crypto.Hash import keccak
ImportError: No module named 'Crypto'
```