### PR TITLE
Generating addresses for DASH testnet

### DIFF
--- a/pywallet/utils/bip32.py
+++ b/pywallet/utils/bip32.py
@@ -657,6 +657,8 @@ class Wallet(object):
             response = BitcoinGoldMainNet
         elif network == "dash" or network == "DASH":
             response = DashMainNet
+        elif network == 'dash_testnet' or network == 'DASHTEST':
+            response = DashTestNet
         else:
             response = network
         return response

--- a/pywallet/utils/bip32.py
+++ b/pywallet/utils/bip32.py
@@ -131,7 +131,7 @@ class Wallet(object):
             else:
                 raise ValueError("parameter must be an int or long")
 
-        self.network = network
+        self.network = Wallet.get_network(network)
         self.depth = l(depth)
         if (isinstance(parent_fingerprint, six.string_types) or
                 isinstance(parent_fingerprint, six.binary_type)):

--- a/pywallet/wallet.py
+++ b/pywallet/wallet.py
@@ -80,6 +80,8 @@ def get_network(network='btctest'):
         return BitcoinGoldMainNet
     elif network == "dash" or network == "dash":
         return DashMainNet
+    elif network == "dash_testnet" or network == 'dashtest':
+        return DashTestNet
 
     return BitcoinTestNet
 


### PR DESCRIPTION
This fixes errors when trying to generate addresses for DASH testnet. 
Now, DASH testnet address can be generated as follows:
```
from pywallet import wallet
w = wallet.create_wallet(network="dashtest")
```