### PR TITLE
Remove rlp dependency

### DIFF
--- a/pywallet/utils/ethereum.py
+++ b/pywallet/utils/ethereum.py
@@ -12,6 +12,7 @@ wallets."""
 import math
 import base58
 import base64
+import binascii
 import hashlib
 import hmac
 from mnemonic.mnemonic import Mnemonic
@@ -24,8 +25,6 @@ from two1.crypto.ecdsa import ECPointAffine
 from two1.crypto.ecdsa import secp256k1
 
 bitcoin_curve = secp256k1()
-
-from rlp.utils import encode_hex
 
 from Crypto.Hash import keccak
 sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
@@ -743,7 +742,7 @@ class PublicKey(PublicKeyBase):
             bytes: Base58Check encoded string
         """
         version = '0x'
-        return version + encode_hex(self.keccak[12:])
+        return version + binascii.hexlify(self.keccak[12:]).decode('ascii')
         # Put the version byte in front, 0x00 for Mainnet, 0x6F for testnet
         # version = bytes([self.TESTNET_VERSION]) if testnet else bytes([self.MAINNET_VERSION])
         # return base58.b58encode_check(version + self.hash160(compressed))

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,5 @@ setup(
         'six>=1.8.0',
         'two1>=3.10.8',
         'pycryptodome==3.4.7',
-        'rlp>=0.6.0'
     ]
 )


### PR DESCRIPTION
_pyrlp_ removed `rlp.utils.encode_hex` and so pywallet is broken. (See: https://github.com/ethereum/pyrlp/issues/96)

But the only reason that you add rlp for this library is hexadecimal encoding and we don't need external library for do that.
So, I made this PR that does hexadecimal encode using only builtin library.

It fixes #21 