### PR TITLE
fix dependancy mismatch

### DIFF
--- a/pywallet/utils/ethereum.py
+++ b/pywallet/utils/ethereum.py
@@ -12,6 +12,7 @@ wallets."""
 import math
 import base58
 import base64
+import binascii
 import hashlib
 import hmac
 from mnemonic.mnemonic import Mnemonic
@@ -24,8 +25,6 @@ from two1.crypto.ecdsa import ECPointAffine
 from two1.crypto.ecdsa import secp256k1
 
 bitcoin_curve = secp256k1()
-
-from rlp.utils import encode_hex
 
 from Crypto.Hash import keccak
 sha3_256 = lambda x: keccak.new(digest_bits=256, data=x)
@@ -743,7 +742,7 @@ class PublicKey(PublicKeyBase):
             bytes: Base58Check encoded string
         """
         version = '0x'
-        return version + encode_hex(self.keccak[12:])
+        return version + binascii.hexlify(self.keccak[12:]).decode('ascii')
         # Put the version byte in front, 0x00 for Mainnet, 0x6F for testnet
         # version = bytes([self.TESTNET_VERSION]) if testnet else bytes([self.MAINNET_VERSION])
         # return base58.b58encode_check(version + self.hash160(compressed))

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     packages = find_packages(exclude=['contrib', 'docs', 'tests', 'demo', 'demos', 'examples']),
     package_data={'': ['AUTHORS', 'LICENSE']},
     install_requires=[
-        'base58==0.2.1',
+        'base58==0.2.2',
         'ecdsa==0.11',
         'six>=1.8.0',
         'two1>=3.10.8',

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,5 @@ setup(
         'six>=1.8.0',
         'two1>=3.10.8',
         'pycryptodome==3.4.7',
-        'rlp>=0.6.0'
     ]
 )


### PR DESCRIPTION
With pipenv, installation fails due to a dependency mismatch. pywallet asks for base58 to be at 0.2.1, however the dependency two1 requires base58 to be at 0.2.2.

This addresses that by changing pywallet's required version of base58 to 0.2.2